### PR TITLE
Delete back-end/node_modules/@strapi/review-workflows/dist/admin/src/…

### DIFF
--- a/back-end/node_modules/@strapi/review-workflows/dist/admin/src/routes/settings/:id.d.ts
+++ b/back-end/node_modules/@strapi/review-workflows/dist/admin/src/routes/settings/:id.d.ts
@@ -1,4 +1,0 @@
-declare const ProtectedEditPage: () => import("react/jsx-runtime").JSX.Element;
-export { ProtectedEditPage };
-//cambiar el nombre a :id.d.ts luego de clonar, porque si tienes windows 
-//no se logran clonar las carpetas por este problema 


### PR DESCRIPTION
…routes/settings/:id.d.ts

el archivo es problematico con windows, no permite la clonacion correcta